### PR TITLE
Add Django as a supported server-side adapter in the introduction

### DIFF
--- a/v2/getting-started/index.mdx
+++ b/v2/getting-started/index.mdx
@@ -10,7 +10,7 @@ Inertia has no client-side routing, nor does it require an API. Simply build con
 
 ## Not a Framework
 
-Inertia isn't a framework, nor is it a replacement for your existing server-side or client-side frameworks. Rather, it's designed to work with them. Think of Inertia as glue that connects the two. Inertia does this via adapters. We currently have three official client-side adapters (React, Vue, and Svelte) and three server-side adapters (Laravel, Rails, and Phoenix).
+Inertia isn't a framework, nor is it a replacement for your existing server-side or client-side frameworks. Rather, it's designed to work with them. Think of Inertia as glue that connects the two. Inertia does this via adapters. We currently have three official client-side adapters (React, Vue, and Svelte) and four server-side adapters (Laravel, Rails, Phoenix, and Django).
 
 ## Next Steps
 


### PR DESCRIPTION
This PR updates the Inertia.js documentation to include Django as one of the officially supported server-side adapters.

The introduction previously listed only three adapters (Laravel, Rails, Phoenix), and this change ensures the docs reflect the newly available Django adapter.