### PR TITLE
Remove toast property from flash data object

### DIFF
--- a/v2/data-props/flash-data.mdx
+++ b/v2/data-props/flash-data.mdx
@@ -62,8 +62,8 @@ const page = usePage()
 </script>
 
 <template>
-    <div v-if="page.flash.toast" class="toast">
-        {{ page.flash.toast.message }}
+    <div v-if="page.flash" class="toast">
+        {{ page.flash.message }}
     </div>
 </template>
 ```
@@ -76,7 +76,7 @@ export default function Layout({ children }) {
 
     return (
         <>
-            {flash.toast && <div className="toast">{flash.toast.message}</div>}
+            {flash && <div className="toast">{flash.message}</div>}
             {children}
         </>
     )
@@ -89,7 +89,7 @@ export default function Layout({ children }) {
 </script>
 
 {#if $page.flash.toast}
-    <div class="toast">{$page.flash.toast.message}</div>
+    <div class="toast">{$page.flash.message}</div>
 {/if}
 ```
 


### PR DESCRIPTION
Hi there,

This PR involves removing a `toast` property from `flash` object, because as it seemed for me, earlier in examples we only have:
```php
Inertia::flash([
        'message' => 'User created!',
        'newUserId' => $user->id,
    ]);
```
and not:
```php
Inertia::flash([
        'toast' => ['message' => 'User created!', ...]
    ]);
```
Hope it does make sense, at least I've spent quite a few dozen of minutes figuring out, that there is no `toast` property on `flash` object, but only what I had already specified. Maybe I'm wrong and you can correct me, but in reality there's no `toast` on `flash` by default as I thought.

Thanks. 