### PR TITLE
Add missing fragments to react form examples

### DIFF
--- a/v2/the-basics/forms.mdx
+++ b/v2/the-basics/forms.mdx
@@ -310,15 +310,17 @@ The `<Form>` component exposes reactive state and helper methods through its def
         reset,
         submit,
     }) => (
-        <input type="text" name="name" />
+        <>
+            <input type="text" name="name" />
 
-        {errors.name && <div>{errors.name}</div>}
+            {errors.name && <div>{errors.name}</div>}
 
-        <button type="submit" disabled={processing}>
-            {processing ? 'Creating...' : 'Create User'}
-        </button>
+            <button type="submit" disabled={processing}>
+                {processing ? 'Creating...' : 'Create User'}
+            </button>
 
-        {wasSuccessful && <div>User created successfully!</div>}
+            {wasSuccessful && <div>User created successfully!</div>}
+        </>
     )}
 </Form>
 ```
@@ -409,8 +411,10 @@ The `errors` object uses dotted notation for nested fields, allowing you to disp
 ```jsx React icon="react"
 <Form action="/users" method="post">
     {({ errors }) => (
-        <input type="text" name="user.name" />
-        {errors['user.name'] && <div>{errors['user.name']}</div>}
+        <>
+            <input type="text" name="user.name" />
+            {errors['user.name'] && <div>{errors['user.name']}</div>}
+        </>
     )}
 </Form>
 ```

--- a/v3/the-basics/forms.mdx
+++ b/v3/the-basics/forms.mdx
@@ -326,15 +326,17 @@ The `<Form>` component exposes reactive state and helper methods through its def
         reset,
         submit,
     }) => (
-        <input type="text" name="name" />
+        <>
+            <input type="text" name="name" />
 
-        {errors.name && <div>{errors.name}</div>}
+            {errors.name && <div>{errors.name}</div>}
 
-        <button type="submit" disabled={processing}>
-            {processing ? 'Creating...' : 'Create User'}
-        </button>
+            <button type="submit" disabled={processing}>
+                {processing ? 'Creating...' : 'Create User'}
+            </button>
 
-        {wasSuccessful && <div>User created successfully!</div>}
+            {wasSuccessful && <div>User created successfully!</div>}
+        </>
     )}
 </Form>
 ```
@@ -391,8 +393,10 @@ The `errors` object uses dotted notation for nested fields, allowing you to disp
 ```jsx React icon="react"
 <Form action="/users" method="post">
     {({ errors }) => (
-        <input type="text" name="user.name" />
-        {errors['user.name'] && <div>{errors['user.name']}</div>}
+        <>
+            <input type="text" name="user.name" />
+            {errors['user.name'] && <div>{errors['user.name']}</div>}
+        </>
     )}
 </Form>
 ```


### PR DESCRIPTION
Before:
<img width="740" height="338" alt="Screenshot 2026-03-19 at 21 14 27" src="https://github.com/user-attachments/assets/ca717684-715a-45c6-9d64-a65619c93da1" />

After:
<img width="696" height="287" alt="Screenshot 2026-03-19 at 21 17 03" src="https://github.com/user-attachments/assets/e1c94924-05de-41e7-9f9e-7c055385501e" />

