### PR TITLE
Add ASP.NET Core adapter to community adapters list

### DIFF
--- a/v3/installation/community-adapters.mdx
+++ b/v3/installation/community-adapters.mdx
@@ -7,6 +7,7 @@ numerous community built server-side adapters available:
 
 - [AdonisJS](https://docs.adonisjs.com/guides/inertia)
 - [ASP.NET](https://github.com/kapi2289/InertiaCore)
+- [ASP.NET Core](https://github.com/pmd-coutinho/dotnet-inertia-adapter)
 - [CakePHP InertiaJS Plugin](https://github.com/CakeDC/cakephp-inertia)
 - [CakePHP](https://github.com/ishanvyas22/cakephp-inertiajs)
 - [CanJS](https://github.com/cherifGsoul/inertia-can)


### PR DESCRIPTION
Add the adapter I created for ASP.NET Core to the list (there is also a wayfinder implementation for dotnet in the repo)