### PR TITLE
fix: React InfiniteScroll template ref examples

### DIFF
--- a/v2/data-props/infinite-scroll.mdx
+++ b/v2/data-props/infinite-scroll.mdx
@@ -777,9 +777,9 @@ export default ({ users }) => {
     return (
         <InfiniteScroll
             data="users"
-            itemsElement={() => tableBody.current}
-            startElement={() => tableHeader.current}
-            endElement={() => tableFooter.current}
+            itemsElement={tableBody}
+            startElement={tableHeader}
+            endElement={tableFooter}
 >
             <table>
                 <thead ref={tableHeader}>

--- a/v3/data-props/infinite-scroll.mdx
+++ b/v3/data-props/infinite-scroll.mdx
@@ -792,9 +792,9 @@ export default ({ users }) => {
   return (
     <InfiniteScroll
       data="users"
-      itemsElement={() => tableBody.current}
-      startElement={() => tableHeader.current}
-      endElement={() => tableFooter.current}
+      itemsElement={tableBody}
+      startElement={tableHeader}
+      endElement={tableFooter}
     >
       <table>
         <thead ref={tableHeader}>


### PR DESCRIPTION
## Background
I realized that when I used the [code](https://inertiajs.com/docs/v3/data-props/infinite-scroll#:~:text=%3CInfiniteScroll%0A%20%20%20%20%20%20data%3D%22users%22%0A%20%20%20%20%20%20itemsElement%3D%7B()%20%3D%3E%20tableBody.current%7D%0A%20%20%20%20%20%20startElement%3D%7B()%20%3D%3E%20tableHeader.current%7D%0A%20%20%20%20%20%20endElement%3D%7B()%20%3D%3E%20tableFooter.current%7D%0A%20%20%20%20%3E) described above with React and infinite scroll, I got a type error, and when I checked the code, it seemed like it didn't accept functions. So I thought the documentation might be incorrect, and I modified it in a way that worked for me.
I might be wrong, so if the documentation is correct, I'd appreciate it if you could let me know.

## Summary

Fix the React `InfiniteScroll` template ref examples in the v2 and v3 documentation.

The React adapter accepts CSS selector strings or React ref objects for `itemsElement`, `startElement`, and `endElement`. The existing React examples pass functions returning `ref.current`, which do not satisfy the prop types and are not handled by the React element resolver.
- [InfiniteScroll.ts - v3](https://github.com/inertiajs/inertia/blob/3.x/packages/react/src/InfiniteScroll.ts#L63-L66)
- [InfiniteScroll.ts - v2](https://github.com/inertiajs/inertia/blob/2.x/packages/react/src/InfiniteScroll.ts#L62-L65)

This updates the React examples to pass the ref objects directly.

## Verification

- Reproduced three `TS2322` errors using the documented function form with `@inertiajs/react` 3.3.1 and strict TypeScript.
- Confirmed that passing the ref objects directly resolves the type errors.
- Confirmed the React adapter types and element resolver accept strings and ref objects, but not functions.
