### PR TITLE
Add webkul/inertia Core PHP + WordPress Adapter

### DIFF
--- a/v3/installation/community-adapters.mdx
+++ b/v3/installation/community-adapters.mdx
@@ -13,6 +13,7 @@ numerous community built server-side adapters available:
 - [CanJS](https://github.com/cherifGsoul/inertia-can)
 - [Clojure](https://github.com/prestancedesign/inertia-clojure)
 - [ColdBox](https://github.com/elpete/cbInertia)
+- [Core PHP](https://github.com/webkul/inertia)
 - [Django](https://pypi.org/project/inertia-django/)
 - [Echo](https://github.com/kohkimakimoto/inertia-echo)
 - [Flask](https://github.com/j0ack/flask-inertia)
@@ -38,4 +39,3 @@ numerous community built server-side adapters available:
 - [WordPress](https://github.com/evo-mark/inertia-wordpress)
 - [Yii2](https://github.com/tbreuss/yii2-inertia)
 - [Yii3](https://github.com/maskulabs/inertia-yii)
-- [Core PHP](https://github.com/webkul/inertia)

--- a/v3/installation/community-adapters.mdx
+++ b/v3/installation/community-adapters.mdx
@@ -38,3 +38,4 @@ numerous community built server-side adapters available:
 - [WordPress](https://github.com/evo-mark/inertia-wordpress)
 - [Yii2](https://github.com/tbreuss/yii2-inertia)
 - [Yii3](https://github.com/maskulabs/inertia-yii)
+- [Core PHP](https://github.com/webkul/inertia)


### PR DESCRIPTION
Adds webkul/inertia, a framework-agnostic PHP server-side adapter implementing the full Inertia protocol (standard visits, XHR visits, 409 stale-asset handshake, partial reloads with lazy prop resolution). It runs on plain PHP with no required framework, and automatically integrates with WordPress when loaded in that environment (uses wp_json_encode, sanitize_text_field, wp_head/wp_footer, etc.) with zero configuration.

Repo: https://github.com/webkul/inertia
License: MIT
Includes runnable examples for React and vanilla JS
Tagged release: 1.0.2